### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A comprehensive MCP (Model Context Protocol) server for browser automation using Playwright. This server provides powerful tools for web scraping, testing, and automation.
 
+<a href="https://glama.ai/mcp/servers/@jomon003/PlayMCP">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@jomon003/PlayMCP/badge" alt="PlayBrowser Automation Server MCP server" />
+</a>
+
 ## Features
 
 ### Core Browser Controls


### PR DESCRIPTION
This PR adds a badge for the [PlayMCP Browser Automation Server](https://glama.ai/mcp/servers/@jomon003/PlayMCP) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@jomon003/PlayMCP">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@jomon003/PlayMCP/badge" alt="PlayBrowser Automation Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.